### PR TITLE
Support namespace provider

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -145,7 +145,7 @@ dotnet_naming_symbols.all_members.applicable_kinds = *
 
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
-file_header_template = Copyright (c) $CURRENT_YEAR$ Koji Hasegawa.\nThis software is released under the MIT License.
+file_header_template = Copyright (c) 2021-$CURRENT_YEAR$ Koji Hasegawa.\nThis software is released under the MIT License.
 
 # RS0016: Only enable if API files are present
 dotnet_public_api_analyzer.require_api_files = true

--- a/Editor/AssemblyInfo.cs
+++ b/Editor/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) 2021-2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("CreateScriptFoldersWithTests.Editor.Tests")]

--- a/Editor/AssemblyInfo.cs.meta
+++ b/Editor/AssemblyInfo.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d2cc8d0d0da8463b9000ef3c720f9a6a
+timeCreated: 1676239843

--- a/Editor/DoCreateScriptFoldersWithTests.cs
+++ b/Editor/DoCreateScriptFoldersWithTests.cs
@@ -65,7 +65,10 @@ namespace CreateScriptFoldersWithTests.Editor
                 asmdef.AddReferences(moduleName);
             }
 
-            asmdef.rootNamespace = assemblyName.Replace($".{Tests}", "");
+            if (IsUnderPackages(pathName))
+            {
+                asmdef.rootNamespace = moduleName;
+            }
 
             var path = Path.Combine(
                 PathCombineAllowNull(pathName, firstLayerName), secondLayerName, $"{assemblyName}.asmdef");
@@ -105,6 +108,11 @@ namespace CreateScriptFoldersWithTests.Editor
         private static bool IsUnderAssets(string pathName)
         {
             return pathName.StartsWith("Assets/");
+        }
+
+        private static bool IsUnderPackages(string pathName)
+        {
+            return !IsUnderAssets(pathName);
         }
 
         private static string PathCombineAllowNull(string pathName, string firstLayerName)

--- a/Editor/Internals.meta
+++ b/Editor/Internals.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 593a7c310cb6469484b0fd87ae87ad29
+timeCreated: 1676298117

--- a/Editor/Internals/DotSettingsCreator.cs
+++ b/Editor/Internals/DotSettingsCreator.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2021-2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace CreateScriptFoldersWithTests.Editor.Internals
+{
+    internal class DotSettingsCreator
+    {
+        private readonly string _assemblyName;
+        private readonly List<string> _namespaceFoldersToSkip;
+
+        public DotSettingsCreator(string assemblyName)
+        {
+            _assemblyName = assemblyName;
+            _namespaceFoldersToSkip = new List<string>();
+        }
+
+        public void AddNamespaceFoldersToSkip(string path)
+        {
+            var key = path
+                .ToLower()
+                .Replace("/", "_005C")
+                .Replace(".", "_002E")
+                .Replace("-", "_002D")
+                .Replace(" ", "_0020")
+                .Replace("(", "_0028")
+                .Replace(")", "_0029");
+
+            _namespaceFoldersToSkip.Add(
+                $"<s:Boolean x:Key=\"/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/={key}/@EntryIndexedValue\">True</s:Boolean>");
+        }
+
+        public bool WasAddNamespaceFoldersToSkip()
+        {
+            return _namespaceFoldersToSkip.Any();
+        }
+
+        public void Flush()
+        {
+            using (var writer = new StreamWriter($"{_assemblyName}.csproj.DotSettings"))
+            {
+                writer.WriteLine(
+                    "<wpf:ResourceDictionary xml:space=\"preserve\" xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\" xmlns:s=\"clr-namespace:System;assembly=mscorlib\" xmlns:ss=\"urn:shemas-jetbrains-com:settings-storage-xaml\" xmlns:wpf=\"http://schemas.microsoft.com/winfx/2006/xaml/presentation\">");
+                foreach (var s in _namespaceFoldersToSkip)
+                {
+                    writer.WriteLine(s);
+                }
+
+                writer.WriteLine("</wpf:ResourceDictionary>");
+            }
+        }
+    }
+}

--- a/Editor/Internals/DotSettingsCreator.cs.meta
+++ b/Editor/Internals/DotSettingsCreator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f5348cad1e434e1fa6b0bff7e31349bd
+timeCreated: 1676231661

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ And the references of each asmdef are set as follows.
 - `YourFeature.Tests` has references to `YourFeature`
 - `YourFeature.Editor.Tests` has references to `YourFeature` and `YourFeature.Editor`
 
+It also creates DotSettings files including disable [Namespace provider](https://www.jetbrains.com/help/rider/Refactorings__Adjust_Namespaces.html) setting.
+
 
 ### Using under Packages folder:
 
@@ -61,7 +63,7 @@ Packages
 After creating folders, move the Editor, Runtime and Tests folders directly under the "your.package.name" folder.
 And remove the "YourFeature" folder.
 
-Then it will be the same as the official [Package layout](https://docs.unity3d.com/Manual/cus-layout.html).
+Then it will be the same as the official [package layout](https://docs.unity3d.com/Manual/cus-layout.html).
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 [![Test](https://github.com/nowsprinting/create-script-folders-with-tests/actions/workflows/test.yml/badge.svg)](https://github.com/nowsprinting/create-script-folders-with-tests/actions/workflows/test.yml)
 [![openupm](https://img.shields.io/npm/v/com.nowsprinting.create-script-folders-with-tests?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/com.nowsprinting.create-script-folders-with-tests/)
 
-This Unity Editor Extensions create script folders (Editor, Runtime, and each Tests) containing assembly definition file (.asmdef).
+This Unity editor extensions create script folders (Editor, Runtime, and each Tests) containing assembly definition file (.asmdef).
 
 
-### Using under Assets folder:
+## Features
 
 When opening the context menu and select **Create | C# Script Folders and Assemblies with Tests**,
 The root folder (e.g., named "YourFeature") and below will be created as follows.
+
+### Creating folders and asmdefs
+
+#### Using under Assets folder
 
 ```
 Assets
@@ -27,23 +31,7 @@ Assets
            └── YourFeature.Tests.asmdef
 ```
 
-And the references of each asmdef are set as follows.
-
-- `YourFeature` has not references
-- `YourFeature.Editor` has references to `YourFeature`
-- `YourFeature.Tests` has references to `YourFeature`
-- `YourFeature.Editor.Tests` has references to `YourFeature` and `YourFeature.Editor`
-
-It also creates DotSettings files including disable [Namespace provider](https://www.jetbrains.com/help/rider/Refactorings__Adjust_Namespaces.html) setting.
-
-
-### Using under Packages folder:
-
-First, your package folder (e.g., named "your.package.name") must be created in advance.
-Because can not open the context menu directly under the Packages folder.
-
-Next, opening the context menu and select **Create | C# Script Folders and Assemblies with Tests**,
-The root folder (e.g., named "YourFeature") and below will be created as follows.
+#### Using under Packages folder
 
 ```
 Packages
@@ -60,10 +48,62 @@ Packages
               └── YourFeature.Tests.asmdef
 ```
 
+Package folder (e.g., named "your.package.name") must be created in before.
+Because can not open the context menu directly under the Packages folder.
+
 After creating folders, move the Editor, Runtime and Tests folders directly under the "your.package.name" folder.
 And remove the "YourFeature" folder.
-
 Then it will be the same as the official [package layout](https://docs.unity3d.com/Manual/cus-layout.html).
+
+```
+Packages
+└── your.package.name
+   ├── Editor
+   │   └── YourFeature.Editor.asmdef
+   ├── Runtime
+   │   └── YourFeature.asmdef
+   └── Tests
+       ├── Editor
+       │   └── YourFeature.Editor.Tests.asmdef
+       └── Runtime
+           └── YourFeature.Tests.asmdef
+```
+
+
+### Assembly Definition References in asmdefs
+
+"Assembly Definition References" in each asmdef are set as follows.
+
+- `YourFeature.Editor` has references to `YourFeature`
+- `YourFeature` has not references
+- `YourFeature.Tests` has references to `YourFeature`
+- `YourFeature.Editor.Tests` has references to `YourFeature` and `YourFeature.Editor`
+
+
+### Creating DotSettings files
+
+And creating .csproj.DotSettings file for each assembly.
+This file is set up to make the "Namespace does not correspond to file location" inspection work as expected in JetBrains Rider.
+Do not forget to commit .DotSettings files for that project.
+
+Specifically, disabled the [Namespace provider](https://www.jetbrains.com/help/rider/Refactorings__Adjust_Namespaces.html) for the following folders.
+
+- Scripts
+- Scripts/Runtime
+- Tests
+- Tests/Runtime
+
+This will result in the expected namespace per folder as follows.
+
+- Scripts/Editor: YourFeature.Editor
+- Scripts/Runtime: YourFeature
+- Tests/Editor: YourFeature.Editor
+- Tests/Runtime: YourFeature
+
+See more information:
+
+- [Code Inspections in C# | JetBrains Rider Documentation](https://www.jetbrains.com/help/rider/Reference__Code_Inspections_CSHARP.html)
+- [Code Inspection: Namespace does not correspond to file location | JetBrains Rider Documentation](https://www.jetbrains.com/help/rider/CheckNamespace.html)
 
 
 ## Installation

--- a/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
+++ b/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
@@ -49,7 +49,7 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.defineConstraints, Is.Empty);
             Assert.That(asmdef.includePlatforms, Is.Empty);
             Assert.That(asmdef.references, Is.Empty);
-            Assert.That(asmdef.rootNamespace, Is.EqualTo(AssemblyName));
+            Assert.That(asmdef.rootNamespace, Is.Empty);
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.defineConstraints, Is.Empty);
             Assert.That(asmdef.includePlatforms, Does.Contain("Editor"));
             Assert.That(asmdef.references, Does.Contain(ModuleName));
-            Assert.That(asmdef.rootNamespace, Is.EqualTo(AssemblyName));
+            Assert.That(asmdef.rootNamespace, Is.Empty);
         }
 
         [Test]
@@ -94,7 +94,7 @@ namespace CreateScriptFoldersWithTests.Editor
 #else
             Assert.That(asmdef.optionalUnityReferences, Does.Contain("TestAssemblies"));
 #endif
-            Assert.That(asmdef.rootNamespace, Is.EqualTo(ModuleName));
+            Assert.That(asmdef.rootNamespace, Is.Empty);
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace CreateScriptFoldersWithTests.Editor
 #else
             Assert.That(asmdef.optionalUnityReferences, Does.Contain("TestAssemblies"));
 #endif
-            Assert.That(asmdef.rootNamespace, Is.EqualTo(EditorAssemblyName));
+            Assert.That(asmdef.rootNamespace, Is.Empty);
         }
     }
 }

--- a/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
+++ b/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
@@ -12,15 +12,25 @@ namespace CreateScriptFoldersWithTests.Editor
     public class DoCreateScriptFoldersWithTestsTest
     {
         private const string ModuleName = "CreateScriptFoldersWithTestsTarget";
+        private const string DotSettingsSuffix = ".csproj.DotSettings";
         private readonly string _rootFolderPath = Path.Combine("Assets", ModuleName);
+        private static readonly string s_rootEncoded = "assets_005C" + ModuleName.ToLower();
+        private static readonly string s_foldersToSkipScripts = $"{s_rootEncoded}_005Cscripts/";
+        private static readonly string s_foldersToSkipScriptsRuntime = $"{s_rootEncoded}_005Cscripts_005Cruntime/";
+        private static readonly string s_foldersToSkipTests = $"{s_rootEncoded}_005Ctests/";
+        private static readonly string s_foldersToSkipTestsRuntime = $"{s_rootEncoded}_005Ctests_005Cruntime/";
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
             AssetDatabase.DisallowAutoRefresh();
 
-            var exist = AssetDatabase.IsValidFolder(_rootFolderPath);
-            Assume.That(exist, Is.False, "Generated folder does not exist before test");
+            // Generated folder and files does not exist before test
+            Assume.That(AssetDatabase.IsValidFolder(_rootFolderPath), Is.False);
+            Assume.That(new FileInfo(ModuleName + DotSettingsSuffix), Does.Not.Exist);
+            Assume.That(new FileInfo(ModuleName + ".Editor" + DotSettingsSuffix), Does.Not.Exist);
+            Assume.That(new FileInfo(ModuleName + ".Tests" + DotSettingsSuffix), Does.Not.Exist);
+            Assume.That(new FileInfo(ModuleName + ".Editor.Tests" + DotSettingsSuffix), Does.Not.Exist);
 
             var sut = ScriptableObject.CreateInstance<DoCreateScriptFoldersWithTests>();
             sut.Action(0, _rootFolderPath, null);
@@ -50,6 +60,13 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.includePlatforms, Is.Empty);
             Assert.That(asmdef.references, Is.Empty);
             Assert.That(asmdef.rootNamespace, Is.Empty);
+
+            const string DotSettingsPath = AssemblyName + DotSettingsSuffix;
+            Assume.That(new FileInfo(DotSettingsPath), Does.Exist);
+            Assert.That(File.ReadAllText(DotSettingsPath), Does.Contain(s_foldersToSkipScripts));
+            Assert.That(File.ReadAllText(DotSettingsPath), Does.Contain(s_foldersToSkipScriptsRuntime));
+
+            File.Delete(DotSettingsPath);
         }
 
         [Test]
@@ -68,6 +85,12 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.includePlatforms, Does.Contain("Editor"));
             Assert.That(asmdef.references, Does.Contain(ModuleName));
             Assert.That(asmdef.rootNamespace, Is.Empty);
+
+            const string DotSettingsPath = AssemblyName + DotSettingsSuffix;
+            Assume.That(new FileInfo(DotSettingsPath), Does.Exist);
+            Assert.That(File.ReadAllText(DotSettingsPath), Does.Contain(s_foldersToSkipScripts));
+
+            File.Delete(DotSettingsPath);
         }
 
         [Test]
@@ -95,6 +118,13 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.optionalUnityReferences, Does.Contain("TestAssemblies"));
 #endif
             Assert.That(asmdef.rootNamespace, Is.Empty);
+
+            const string DotSettingsPath = AssemblyName + DotSettingsSuffix;
+            Assume.That(new FileInfo(DotSettingsPath), Does.Exist);
+            Assert.That(File.ReadAllText(DotSettingsPath), Does.Contain(s_foldersToSkipTests));
+            Assert.That(File.ReadAllText(DotSettingsPath), Does.Contain(s_foldersToSkipTestsRuntime));
+
+            File.Delete(DotSettingsPath);
         }
 
         [Test]
@@ -124,6 +154,12 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.optionalUnityReferences, Does.Contain("TestAssemblies"));
 #endif
             Assert.That(asmdef.rootNamespace, Is.Empty);
+
+            const string DotSettingsPath = AssemblyName + DotSettingsSuffix;
+            Assume.That(new FileInfo(DotSettingsPath), Does.Exist);
+            Assert.That(File.ReadAllText(DotSettingsPath), Does.Contain(s_foldersToSkipTests));
+
+            File.Delete(DotSettingsPath);
         }
     }
 }

--- a/Tests/Editor/DoCreateScriptFoldersWithTestsTestUnderPackages.cs
+++ b/Tests/Editor/DoCreateScriptFoldersWithTestsTestUnderPackages.cs
@@ -52,7 +52,7 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.defineConstraints, Is.Empty);
             Assert.That(asmdef.includePlatforms, Is.Empty);
             Assert.That(asmdef.references, Is.Empty);
-            Assert.That(asmdef.rootNamespace, Is.EqualTo(AssemblyName));
+            Assert.That(asmdef.rootNamespace, Is.EqualTo(ModuleName));
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.defineConstraints, Is.Empty);
             Assert.That(asmdef.includePlatforms, Does.Contain("Editor"));
             Assert.That(asmdef.references, Does.Contain(ModuleName));
-            Assert.That(asmdef.rootNamespace, Is.EqualTo(AssemblyName));
+            Assert.That(asmdef.rootNamespace, Is.EqualTo(ModuleName));
         }
 
         [Test]
@@ -127,7 +127,7 @@ namespace CreateScriptFoldersWithTests.Editor
 #else
             Assert.That(asmdef.optionalUnityReferences, Does.Contain("TestAssemblies"));
 #endif
-            Assert.That(asmdef.rootNamespace, Is.EqualTo(EditorAssemblyName));
+            Assert.That(asmdef.rootNamespace, Is.EqualTo(ModuleName));
         }
     }
 }

--- a/Tests/Editor/Helpers.meta
+++ b/Tests/Editor/Helpers.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4c2a8d4d4f77468c8e1730ddfe457fd5
+timeCreated: 1676325968

--- a/Tests/Editor/Helpers/ShrinkSpaceComparer.cs
+++ b/Tests/Editor/Helpers/ShrinkSpaceComparer.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2021-2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+namespace CreateScriptFoldersWithTests.Editor.Helpers
+{
+    /// <summary>
+    /// Consecutive spaces and tabs shrink to a single space
+    /// Ignore line breaks
+    /// </summary>
+    public class ShrinkSpaceComparer : IComparer<string>
+    {
+        /// <inheritdoc />
+        public int Compare(string x, string y)
+        {
+            var compere = string.Compare(Shrink(x), Shrink(y), StringComparison.Ordinal);
+            if (compere == 0)
+            {
+                return 0;
+            }
+
+            Debug.Log($"Expected: \"{Shrink(x)}\"");
+            Debug.Log($"But was:  \"{Shrink(y)}\"");
+
+            return compere;
+        }
+
+        private static string Shrink(string s)
+        {
+            return Regex.Replace(
+                s.Replace(Environment.NewLine, string.Empty),
+                "\\s+", " ");
+        }
+    }
+}

--- a/Tests/Editor/Helpers/ShrinkSpaceComparer.cs.meta
+++ b/Tests/Editor/Helpers/ShrinkSpaceComparer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: db2ed8d1eea0478a8708f30f8cdfeaef
+timeCreated: 1676324954

--- a/Tests/Editor/Internals.meta
+++ b/Tests/Editor/Internals.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2df55e26bbce4550b2d70d6d34cff77c
+timeCreated: 1676298138

--- a/Tests/Editor/Internals/DotSettingsCreatorTests.cs
+++ b/Tests/Editor/Internals/DotSettingsCreatorTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2021-2023 Koji Hasegawa.
+// This software is released under the MIT License.
+
+using System.IO;
+using CreateScriptFoldersWithTests.Editor.Helpers;
+using NUnit.Framework;
+
+namespace CreateScriptFoldersWithTests.Editor.Internals
+{
+    public class DotSettingsCreatorTests
+    {
+        private const string ModuleName = "CreateScriptFoldersWithTestsTarget";
+        private const string DotSettingsSuffix = ".csproj.DotSettings";
+        private const string DotSettingsPath = ModuleName + DotSettingsSuffix;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Assume.That(new FileInfo(DotSettingsPath), Does.Not.Exist);
+        }
+
+        [Test]
+        public void DotSettingsCreator_CreatedDotSettingsFile()
+        {
+            var sut = new DotSettingsCreator(ModuleName);
+            sut.Flush();
+
+            Assert.That(new FileInfo(DotSettingsPath), Does.Exist);
+            Assert.That(File.ReadAllText(DotSettingsPath), Is.EqualTo(@"<wpf:ResourceDictionary
+    xml:space=""preserve""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:s=""clr-namespace:System;assembly=mscorlib""
+    xmlns:ss=""urn:shemas-jetbrains-com:settings-storage-xaml""
+    xmlns:wpf=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"">
+</wpf:ResourceDictionary>")
+                .Using(new ShrinkSpaceComparer()));
+
+            File.Delete(DotSettingsPath);
+        }
+
+        [Test]
+        public void AddNamespaceFoldersToSkip_DotSettingsContainNamespaceFoldersToSkipElement()
+        {
+            var sut = new DotSettingsCreator(ModuleName);
+            sut.AddNamespaceFoldersToSkip("Packages/com.nowsprinting.create-script-folders-with-tests/Foo");
+            sut.AddNamespaceFoldersToSkip("Packages/com.nowsprinting.create-script-folders-with-tests/Foo/Bar");
+            sut.AddNamespaceFoldersToSkip("Packages/com.nowsprinting.create-script-folders-with-tests/New Feature (1)");
+            sut.Flush();
+
+            Assert.That(new FileInfo(DotSettingsPath), Does.Exist);
+            Assert.That(File.ReadAllText(DotSettingsPath), Is.EqualTo(@"<wpf:ResourceDictionary
+    xml:space=""preserve""
+    xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+    xmlns:s=""clr-namespace:System;assembly=mscorlib""
+    xmlns:ss=""urn:shemas-jetbrains-com:settings-storage-xaml""
+    xmlns:wpf=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"">
+<s:Boolean x:Key=""/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=packages_005Ccom_002Enowsprinting_002Ecreate_002Dscript_002Dfolders_002Dwith_002Dtests_005Cfoo/@EntryIndexedValue"">True</s:Boolean>
+<s:Boolean x:Key=""/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=packages_005Ccom_002Enowsprinting_002Ecreate_002Dscript_002Dfolders_002Dwith_002Dtests_005Cfoo_005Cbar/@EntryIndexedValue"">True</s:Boolean>
+<s:Boolean x:Key=""/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=packages_005Ccom_002Enowsprinting_002Ecreate_002Dscript_002Dfolders_002Dwith_002Dtests_005Cnew_0020feature_0020_00281_0029/@EntryIndexedValue"">True</s:Boolean>
+</wpf:ResourceDictionary>")
+                .Using(new ShrinkSpaceComparer()));
+
+            File.Delete(DotSettingsPath);
+        }
+    }
+}

--- a/Tests/Editor/Internals/DotSettingsCreatorTests.cs.meta
+++ b/Tests/Editor/Internals/DotSettingsCreatorTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a507901621de428bbda0ffb3b63b1b11
+timeCreated: 1676231982


### PR DESCRIPTION
- Only set rootNamespace when under Packages
- Creates DotSettings files including disabled Namespace provider setting
- Mod README.md

See https://youtrack.jetbrains.com/issue/RIDER-87752/Interpretation-of-RootNamespace-is-not-as-expected