### PR TITLE
Add specify directories for publishing in the `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "documentationUrl": "https://github.com/nowsprinting/create-script-folders-with-tests/blob/master/README.md",
   "files": [
     "Documentation~",
+    "Editor",
     "Editor*",
+    "Tests",
     "Tests*",
     "CHANGELOG.md*",
     "LICENSE.md*",


### PR DESCRIPTION
Maybe the glob rule changed for the `files` field from Node 16.
It seems `*` only applies to files and skips directories.

see: https://github.com/openupm/openupm-pipelines/issues/14
