### PR TITLE
Add assembly reference from Editor.Tests to Runtime.Tests

### DIFF
--- a/Editor/DoCreateScriptFoldersWithTests.cs
+++ b/Editor/DoCreateScriptFoldersWithTests.cs
@@ -1,13 +1,11 @@
-﻿// Copyright (c) 2021-2023 Koji Hasegawa.
+﻿// Copyright (c) 2021-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.IO;
-using System.Reflection;
 using System.Text;
 using CreateScriptFoldersWithTests.Editor.Internals;
 using UnityEditor;
 using UnityEditor.ProjectWindowCallback;
-using UnityEngine;
 
 namespace CreateScriptFoldersWithTests.Editor
 {
@@ -58,7 +56,15 @@ namespace CreateScriptFoldersWithTests.Editor
             {
                 asmdef.autoReferenced = false;
                 asmdef.SetForTestAssembly();
-                asmdef.AddReferences(secondLayerName == Editor ? $"{moduleName}.{Editor}" : moduleName);
+                if (secondLayerName == Editor)
+                {
+                    asmdef.AddReferences($"{moduleName}.{Editor}");
+                    asmdef.AddReferences($"{moduleName}.{Tests}");
+                }
+                else
+                {
+                    asmdef.AddReferences(moduleName);
+                }
             }
 
             if (secondLayerName == Editor)

--- a/Editor/DoCreateScriptFoldersWithTests.cs
+++ b/Editor/DoCreateScriptFoldersWithTests.cs
@@ -6,6 +6,10 @@ using System.Text;
 using CreateScriptFoldersWithTests.Editor.Internals;
 using UnityEditor;
 using UnityEditor.ProjectWindowCallback;
+#if !UNITY_6000_0_OR_NEWER
+using System.Reflection;
+using UnityEngine;
+#endif
 
 namespace CreateScriptFoldersWithTests.Editor
 {

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ graph RL
     Runtime.Tests --> Runtime
     Editor.Tests --> Runtime
     Editor.Tests --> Editor
+    Editor.Tests --> Runtime.Tests
 ```
 
 

--- a/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
+++ b/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2023 Koji Hasegawa.
+﻿// Copyright (c) 2021-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.IO;
@@ -131,6 +131,7 @@ namespace CreateScriptFoldersWithTests.Editor
         public void Action_CreatedEditorTestsFolderContainingAsmdef()
         {
             const string EditorAssemblyName = ModuleName + ".Editor";
+            const string RuntimeTestAssemblyName = ModuleName + ".Tests";
             const string AssemblyName = EditorAssemblyName + ".Tests";
             var file = AssetDatabase.LoadAssetAtPath<AssemblyDefinitionAsset>(
                 Path.Combine(_rootFolderPath, "Tests", "Editor", $"{AssemblyName}.asmdef"));
@@ -144,6 +145,7 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.includePlatforms, Does.Contain("Editor"));
             Assert.That(asmdef.references, Does.Contain(ModuleName));
             Assert.That(asmdef.references, Does.Contain(EditorAssemblyName));
+            Assert.That(asmdef.references, Does.Contain(RuntimeTestAssemblyName));
 #if UNITY_2019_3_OR_NEWER
             Assert.That(asmdef.references, Does.Contain("UnityEngine.TestRunner"));
             Assert.That(asmdef.references, Does.Contain("UnityEditor.TestRunner"));

--- a/Tests/Editor/DoCreateScriptFoldersWithTestsTestUnderPackages.cs
+++ b/Tests/Editor/DoCreateScriptFoldersWithTestsTestUnderPackages.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2023 Koji Hasegawa.
+﻿// Copyright (c) 2021-2025 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.IO;
@@ -135,6 +135,7 @@ namespace CreateScriptFoldersWithTests.Editor
         public void Action_CreatedEditorTestsFolderContainingAsmdef()
         {
             const string EditorAssemblyName = ModuleName + ".Editor";
+            const string RuntimeTestAssemblyName = ModuleName + ".Tests";
             const string AssemblyName = EditorAssemblyName + ".Tests";
             var file = AssetDatabase.LoadAssetAtPath<AssemblyDefinitionAsset>(
                 Path.Combine(_rootFolderPath, "Tests", "Editor", $"{AssemblyName}.asmdef"));
@@ -148,6 +149,7 @@ namespace CreateScriptFoldersWithTests.Editor
             Assert.That(asmdef.includePlatforms, Does.Contain("Editor"));
             Assert.That(asmdef.references, Does.Contain(ModuleName));
             Assert.That(asmdef.references, Does.Contain(EditorAssemblyName));
+            Assert.That(asmdef.references, Does.Contain(RuntimeTestAssemblyName));
 #if UNITY_2019_3_OR_NEWER
             Assert.That(asmdef.references, Does.Contain("UnityEngine.TestRunner"));
             Assert.That(asmdef.references, Does.Contain("UnityEditor.TestRunner"));


### PR DESCRIPTION
### Changes

Adds an assembly reference from the **Editor.Tests** to **Runtime.Tests** in Unity project assembly definitions.
The change ensures that Editor test assemblies can reference and utilize functionality from Runtime test assemblies.

#### Before

```mermaid
graph RL
    Runtime
    Editor --> Runtime
    Runtime.Tests --> Runtime
    Editor.Tests --> Runtime
    Editor.Tests --> Editor
```

#### After

```mermaid
graph RL
    Runtime
    Editor --> Runtime
    Runtime.Tests --> Runtime
    Editor.Tests --> Runtime
    Editor.Tests --> Editor
    Editor.Tests --> Runtime.Tests
```