### PR TITLE
Add to make friend assemblies

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ graph RL
 ```
 
 
+### Creating AssemblyInfo.cs files for friend assemblies
+
+Creates an AssemblyInfo.cs file for each assembly to mark **Assembly Definition References** as [Friend assemblies](https://learn.microsoft.com/en-us/dotnet/standard/assembly/friend).
+This allows access to `internal` types and members.
+
+
 ### Creating DotSettings files
 
 Creates .csproj.DotSettings file for each assembly.

--- a/README.md
+++ b/README.md
@@ -94,16 +94,8 @@ graph RL
 
 ### Creating DotSettings files
 
-And creating .csproj.DotSettings file for each assembly.
+Creates .csproj.DotSettings file for each assembly.
 This file is set up to make the [Namespace does not correspond to file location](https://www.jetbrains.com/help/rider/CheckNamespace.html) inspection work as expected in JetBrains Rider.
-Do not forget to commit .DotSettings files for that project.
-
-Specifically, disabled the [Namespace provider](https://www.jetbrains.com/help/rider/Refactorings__Adjust_Namespaces.html) for the following folders:
-
-- Scripts
-- Scripts/Runtime
-- Tests
-- Tests/Runtime
 
 This will result in the expected namespace per folder as follows:
 
@@ -111,6 +103,17 @@ This will result in the expected namespace per folder as follows:
 - Scripts/Runtime: `YourFeature`
 - Tests/Editor: `YourFeature.Editor`
 - Tests/Runtime: `YourFeature`
+
+> [!TIP]  
+> `Tests` is not included in the namespace.
+> When the same namespaces as the production code and test code are used, `using` directives are not required.
+
+Specifically, disabled the [Namespace provider](https://www.jetbrains.com/help/rider/Refactorings__Adjust_Namespaces.html) for the following folders:
+
+- Scripts
+- Scripts/Runtime
+- Tests
+- Tests/Runtime
 
 > [!WARNING]  
 > Under Packages namespace resolution works with Unity 2020.2 or later.

--- a/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
+++ b/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
@@ -163,5 +163,53 @@ namespace CreateScriptFoldersWithTests.Editor
 
             File.Delete(DotSettingsPath);
         }
+
+        [Test]
+        public void Action_CreatedRuntimeAssemblyInfoWithInternalsVisibleTo()
+        {
+            var assemblyInfoPath = Path.Combine(_rootFolderPath, "Scripts", "Runtime", "AssemblyInfo.cs");
+            Assume.That(File.Exists(assemblyInfoPath), Is.True);
+
+            var actual = File.ReadAllText(assemblyInfoPath);
+            var expected = "using System.Runtime.CompilerServices;\r\n\r\n"
+                           + $"[assembly: InternalsVisibleTo(\"{ModuleName}.Editor\")]\r\n"
+                           + $"[assembly: InternalsVisibleTo(\"{ModuleName}.Editor.Tests\")]\r\n"
+                           + $"[assembly: InternalsVisibleTo(\"{ModuleName}.Tests\")]\r\n";
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Action_CreatedEditorAssemblyInfoWithInternalsVisibleTo()
+        {
+            var assemblyInfoPath = Path.Combine(_rootFolderPath, "Scripts", "Editor", "AssemblyInfo.cs");
+            Assume.That(File.Exists(assemblyInfoPath), Is.True);
+
+            var actual = File.ReadAllText(assemblyInfoPath);
+            var expected = "using System.Runtime.CompilerServices;\r\n\r\n"
+                           + $"[assembly: InternalsVisibleTo(\"{ModuleName}.Editor.Tests\")]\r\n";
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Action_CreatedTestsRuntimeAssemblyInfoWithInternalsVisibleTo()
+        {
+            var assemblyInfoPath = Path.Combine(_rootFolderPath, "Tests", "Runtime", "AssemblyInfo.cs");
+            Assume.That(File.Exists(assemblyInfoPath), Is.True);
+
+            var actual = File.ReadAllText(assemblyInfoPath);
+            var expected = "using System.Runtime.CompilerServices;\r\n\r\n"
+                           + $"[assembly: InternalsVisibleTo(\"{ModuleName}.Editor.Tests\")]\r\n";
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Action_CreatedEmptyTestsEditorAssemblyInfo()
+        {
+            var assemblyInfoPath = Path.Combine(_rootFolderPath, "Tests", "Editor", "AssemblyInfo.cs");
+            Assume.That(File.Exists(assemblyInfoPath), Is.True);
+
+            var actual = File.ReadAllText(assemblyInfoPath);
+            Assert.That(actual, Is.EqualTo(string.Empty));
+        }
     }
 }

--- a/Tests/Editor/DoCreateScriptFoldersWithTestsTestUnderPackages.cs
+++ b/Tests/Editor/DoCreateScriptFoldersWithTestsTestUnderPackages.cs
@@ -167,5 +167,33 @@ namespace CreateScriptFoldersWithTests.Editor
 
             File.Delete(DotSettingsPath);
         }
+
+        [Test]
+        public void Action_PackagesRuntimeAssemblyInfoPath()
+        {
+            var assemblyInfoPath = Path.Combine(_rootFolderPath, "Runtime", "AssemblyInfo.cs");
+            Assert.That(File.Exists(assemblyInfoPath), Is.True);
+        }
+
+        [Test]
+        public void Action_PackagesEditorAssemblyInfoPath()
+        {
+            var assemblyInfoPath = Path.Combine(_rootFolderPath, "Editor", "AssemblyInfo.cs");
+            Assert.That(File.Exists(assemblyInfoPath), Is.True);
+        }
+
+        [Test]
+        public void Action_PackagesTestsRuntimeAssemblyInfoPath()
+        {
+            var assemblyInfoPath = Path.Combine(_rootFolderPath, "Tests", "Runtime", "AssemblyInfo.cs");
+            Assert.That(File.Exists(assemblyInfoPath), Is.True);
+        }
+
+        [Test]
+        public void Action_PackagesTestsEditorAssemblyInfo()
+        {
+            var assemblyInfoPath = Path.Combine(_rootFolderPath, "Tests", "Editor", "AssemblyInfo.cs");
+            Assert.That(File.Exists(assemblyInfoPath), Is.True);
+        }
     }
 }


### PR DESCRIPTION
### Creating AssemblyInfo.cs files for friend assemblies

Creates an AssemblyInfo.cs file for each assembly to mark **Assembly Definition References** as [Friend assemblies](https://learn.microsoft.com/en-us/dotnet/standard/assembly/friend).
This allows access to `internal` types and members.
