### PR TITLE
Fix CS0618: use EntityId.None for Unity 6000.4 and later

### DIFF
--- a/Editor/CreateScriptFoldersWithTests.Editor.globalconfig
+++ b/Editor/CreateScriptFoldersWithTests.Editor.globalconfig
@@ -1,0 +1,2 @@
+is_global = true
+dotnet_diagnostic.CS0618.severity = error

--- a/Editor/CreateScriptFoldersWithTests.Editor.globalconfig.meta
+++ b/Editor/CreateScriptFoldersWithTests.Editor.globalconfig.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 94769b7534fed40f28436546668b6576
+RoslynAnalyzerConfigImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/CreateScriptFoldersWithTestsMenu.cs
+++ b/Editor/CreateScriptFoldersWithTestsMenu.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2023 Koji Hasegawa.
+﻿// Copyright (c) 2021-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using UnityEditor;
@@ -16,7 +16,11 @@ namespace CreateScriptFoldersWithTests.Editor
         private static void CreateFeatureFolderWithTestsMenuItem()
         {
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(
+#if UNITY_6000_4_OR_NEWER
+                EntityId.None,
+#else
                 0,
+#endif
                 ScriptableObject.CreateInstance<DoCreateScriptFoldersWithTests>(),
                 "New Feature",
                 EditorGUIUtility.IconContent(EditorResources.folderIconName).image as Texture2D,

--- a/Tests/Editor/CreateScriptFoldersWithTests.Editor.Tests.globalconfig
+++ b/Tests/Editor/CreateScriptFoldersWithTests.Editor.Tests.globalconfig
@@ -1,0 +1,2 @@
+is_global = true
+dotnet_diagnostic.CS0618.severity = error

--- a/Tests/Editor/CreateScriptFoldersWithTests.Editor.Tests.globalconfig.meta
+++ b/Tests/Editor/CreateScriptFoldersWithTests.Editor.Tests.globalconfig.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 86ffde57c55ed43c789a11659d948d23
+RoslynAnalyzerConfigImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
+++ b/Tests/Editor/DoCreateScriptFoldersWithTestsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2025 Koji Hasegawa.
+﻿// Copyright (c) 2021-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.IO;
@@ -33,7 +33,11 @@ namespace CreateScriptFoldersWithTests.Editor
             Assume.That(new FileInfo(ModuleName + ".Editor.Tests" + DotSettingsSuffix), Does.Not.Exist);
 
             var sut = ScriptableObject.CreateInstance<DoCreateScriptFoldersWithTests>();
+#if UNITY_6000_4_OR_NEWER
+            sut.Action(EntityId.None, _rootFolderPath, null);
+#else
             sut.Action(0, _rootFolderPath, null);
+#endif
             // I understand that it shouldn't be exercise within OneTimeSetUp. I did not have a choice.
         }
 

--- a/Tests/Editor/DoCreateScriptFoldersWithTestsTestUnderPackages.cs
+++ b/Tests/Editor/DoCreateScriptFoldersWithTestsTestUnderPackages.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2021-2025 Koji Hasegawa.
+﻿// Copyright (c) 2021-2026 Koji Hasegawa.
 // This software is released under the MIT License.
 
 using System.IO;
@@ -38,7 +38,11 @@ namespace CreateScriptFoldersWithTests.Editor
             Assume.That(new FileInfo(ModuleName + ".Editor.Tests" + DotSettingsSuffix), Does.Not.Exist);
 
             var sut = ScriptableObject.CreateInstance<DoCreateScriptFoldersWithTests>();
+#if UNITY_6000_4_OR_NEWER
+            sut.Action(EntityId.None, _rootFolderPath, null);
+#else
             sut.Action(0, _rootFolderPath, null);
+#endif
             // I understand that it shouldn't be exercise within OneTimeSetUp. I did not have a choice.
         }
 


### PR DESCRIPTION
## Summary

- `ProjectWindowUtil.StartNameEditingIfProjectWindowExists` with an `int` first argument became `[Obsolete]` in Unity 6000.4, causing CS0618
- Added `#if UNITY_6000_4_OR_NEWER` branches to pass `EntityId.None` on Unity 6000.4 and later
- Applied the same fix to test code calling `sut.Action(0, ...)`
- Updated copyright year to 2026
- Used `EntityId.None` instead of `(EntityId)0` because the implicit `int↔EntityId` conversion is slated for removal in Unity 6.6

## Test plan

- [x] Confirm no CS0618 warnings/errors on Unity 6000.4.12f1
- [x] Run `Assets/Create/C# Script Folders and Assemblies with Tests` menu and verify folders and asmdef files are generated correctly
- [x] Confirm existing tests (`DoCreateScriptFoldersWithTestsTest`, `DoCreateScriptFoldersWithTestsTestUnderPackages`) pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)