### PR TITLE
Move analyzer severity settings from .editorconfig to globalconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -264,9 +264,6 @@ resharper_csharp_keep_existing_initializer_arrangement = true
 # Some values of the enum are not processed inside 'switch' statement and are handled via default section
 resharper_switch_statement_handles_some_known_enum_values_with_default_highlighting = warning
 
-# BannedApiAnalyzers
-dotnet_diagnostic.RS0030.severity = error
-
 # Suppress C#8.0+ syntax sugar (for under Unity 2020.2 compatibility)
 # See: https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_CSHARP.html
 resharper_convert_to_using_declaration_highlighting = none
@@ -279,9 +276,6 @@ resharper_use_negated_pattern_in_is_expression_highlighting = none
 
 # Access to a static member of a type via a derived type (e.g., NUnit.Framework.Is)
 resharper_access_to_static_member_via_derived_type_highlighting = none
-
-# NUnit2045: Use Assert.Multiple
-dotnet_diagnostic.NUnit2045.severity = none
 
 [src/{Compilers,ExpressionEvaluator,Scripting}/**Test**/*.{cs,vb}]
 

--- a/Editor/CreateScriptFoldersWithTests.Editor.globalconfig
+++ b/Editor/CreateScriptFoldersWithTests.Editor.globalconfig
@@ -1,2 +1,62 @@
 is_global = true
+
+# CS0618: Type or member is obsolete
 dotnet_diagnostic.CS0618.severity = error
+
+# RS0030: Do not use banned APIs
+dotnet_diagnostic.RS0030.severity = error
+
+# Nullable reference type warnings (this package does not use nullable annotations)
+dotnet_diagnostic.CS8597.severity = none
+dotnet_diagnostic.CS8600.severity = none
+dotnet_diagnostic.CS8601.severity = none
+dotnet_diagnostic.CS8602.severity = none
+dotnet_diagnostic.CS8603.severity = none
+dotnet_diagnostic.CS8604.severity = none
+dotnet_diagnostic.CS8605.severity = none
+dotnet_diagnostic.CS8607.severity = none
+dotnet_diagnostic.CS8608.severity = none
+dotnet_diagnostic.CS8609.severity = none
+dotnet_diagnostic.CS8610.severity = none
+dotnet_diagnostic.CS8611.severity = none
+dotnet_diagnostic.CS8612.severity = none
+dotnet_diagnostic.CS8613.severity = none
+dotnet_diagnostic.CS8614.severity = none
+dotnet_diagnostic.CS8615.severity = none
+dotnet_diagnostic.CS8616.severity = none
+dotnet_diagnostic.CS8617.severity = none
+dotnet_diagnostic.CS8618.severity = none
+dotnet_diagnostic.CS8619.severity = none
+dotnet_diagnostic.CS8620.severity = none
+dotnet_diagnostic.CS8621.severity = none
+dotnet_diagnostic.CS8622.severity = none
+dotnet_diagnostic.CS8624.severity = none
+dotnet_diagnostic.CS8625.severity = none
+dotnet_diagnostic.CS8629.severity = none
+dotnet_diagnostic.CS8631.severity = none
+dotnet_diagnostic.CS8633.severity = none
+dotnet_diagnostic.CS8634.severity = none
+dotnet_diagnostic.CS8643.severity = none
+dotnet_diagnostic.CS8644.severity = none
+dotnet_diagnostic.CS8645.severity = none
+dotnet_diagnostic.CS8655.severity = none
+dotnet_diagnostic.CS8667.severity = none
+dotnet_diagnostic.CS8670.severity = none
+dotnet_diagnostic.CS8714.severity = none
+dotnet_diagnostic.CS8762.severity = none
+dotnet_diagnostic.CS8763.severity = none
+dotnet_diagnostic.CS8764.severity = none
+dotnet_diagnostic.CS8765.severity = none
+dotnet_diagnostic.CS8766.severity = none
+dotnet_diagnostic.CS8767.severity = none
+dotnet_diagnostic.CS8768.severity = none
+dotnet_diagnostic.CS8769.severity = none
+dotnet_diagnostic.CS8770.severity = none
+dotnet_diagnostic.CS8774.severity = none
+dotnet_diagnostic.CS8775.severity = none
+dotnet_diagnostic.CS8776.severity = none
+dotnet_diagnostic.CS8777.severity = none
+dotnet_diagnostic.CS8819.severity = none
+dotnet_diagnostic.CS8824.severity = none
+dotnet_diagnostic.CS8825.severity = none
+dotnet_diagnostic.CS8847.severity = none

--- a/Tests/Editor/CreateScriptFoldersWithTests.Editor.Tests.globalconfig
+++ b/Tests/Editor/CreateScriptFoldersWithTests.Editor.Tests.globalconfig
@@ -1,2 +1,68 @@
 is_global = true
+
+# CS0618: Type or member is obsolete
 dotnet_diagnostic.CS0618.severity = error
+
+# RS0030: Do not use banned APIs
+dotnet_diagnostic.RS0030.severity = warning
+
+# Nullable reference type warnings (this package does not use nullable annotations)
+dotnet_diagnostic.CS8597.severity = none
+dotnet_diagnostic.CS8600.severity = none
+dotnet_diagnostic.CS8601.severity = none
+dotnet_diagnostic.CS8602.severity = none
+dotnet_diagnostic.CS8603.severity = none
+dotnet_diagnostic.CS8604.severity = none
+dotnet_diagnostic.CS8605.severity = none
+dotnet_diagnostic.CS8607.severity = none
+dotnet_diagnostic.CS8608.severity = none
+dotnet_diagnostic.CS8609.severity = none
+dotnet_diagnostic.CS8610.severity = none
+dotnet_diagnostic.CS8611.severity = none
+dotnet_diagnostic.CS8612.severity = none
+dotnet_diagnostic.CS8613.severity = none
+dotnet_diagnostic.CS8614.severity = none
+dotnet_diagnostic.CS8615.severity = none
+dotnet_diagnostic.CS8616.severity = none
+dotnet_diagnostic.CS8617.severity = none
+dotnet_diagnostic.CS8618.severity = none
+dotnet_diagnostic.CS8619.severity = none
+dotnet_diagnostic.CS8620.severity = none
+dotnet_diagnostic.CS8621.severity = none
+dotnet_diagnostic.CS8622.severity = none
+dotnet_diagnostic.CS8624.severity = none
+dotnet_diagnostic.CS8625.severity = none
+dotnet_diagnostic.CS8629.severity = none
+dotnet_diagnostic.CS8631.severity = none
+dotnet_diagnostic.CS8633.severity = none
+dotnet_diagnostic.CS8634.severity = none
+dotnet_diagnostic.CS8643.severity = none
+dotnet_diagnostic.CS8644.severity = none
+dotnet_diagnostic.CS8645.severity = none
+dotnet_diagnostic.CS8655.severity = none
+dotnet_diagnostic.CS8667.severity = none
+dotnet_diagnostic.CS8670.severity = none
+dotnet_diagnostic.CS8714.severity = none
+dotnet_diagnostic.CS8762.severity = none
+dotnet_diagnostic.CS8763.severity = none
+dotnet_diagnostic.CS8764.severity = none
+dotnet_diagnostic.CS8765.severity = none
+dotnet_diagnostic.CS8766.severity = none
+dotnet_diagnostic.CS8767.severity = none
+dotnet_diagnostic.CS8768.severity = none
+dotnet_diagnostic.CS8769.severity = none
+dotnet_diagnostic.CS8770.severity = none
+dotnet_diagnostic.CS8774.severity = none
+dotnet_diagnostic.CS8775.severity = none
+dotnet_diagnostic.CS8776.severity = none
+dotnet_diagnostic.CS8777.severity = none
+dotnet_diagnostic.CS8819.severity = none
+dotnet_diagnostic.CS8824.severity = none
+dotnet_diagnostic.CS8825.severity = none
+dotnet_diagnostic.CS8847.severity = none
+
+# NUnit2045: Use Assert.Multiple
+dotnet_diagnostic.NUnit2045.severity = none
+
+# VSTHRD200: Use "Async" suffix for async methods
+dotnet_diagnostic.VSTHRD200.severity = none


### PR DESCRIPTION
## Summary

Move analyzer severity settings from `.editorconfig` to per-assembly `.globalconfig` files. Severities in `.editorconfig` are only honored by the IDE, while `.globalconfig` files are picked up by the Unity compilation, so violations are detected at build time.

- Production assemblies: `CS0618` (obsolete API) and `RS0030` (banned API) escalate to `error`
- Test assemblies: `RS0030` is relaxed to `warning` because tests may need to exercise banned APIs; `NUnit2045` and `VSTHRD200` are disabled because they do not fit the project's test conventions
- All assemblies: nullable reference type diagnostics (`CS86xx`) are disabled because this package does not use nullable annotations
- Remove the moved diagnostics from `.editorconfig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
